### PR TITLE
Fix clf optuna

### DIFF
--- a/clf_optuna.py
+++ b/clf_optuna.py
@@ -5,7 +5,6 @@ import time
 import clf_utils
 
 
-
 def suggest_architecture(trial):
     num_stages = trial.suggest_categorical("num_stages", [3, 4])
     base = trial.suggest_categorical("base_channels", [16, 32, 64])
@@ -53,7 +52,7 @@ def suggest_architecture(trial):
 
 
 def objective(trial, cmd_args):
-    start_time = time.time() 
+    start_time = time.time()
     params = suggest_architecture(trial)
 
     rot = trial.suggest_int("augm_rotation", 5, 20, step=5)
@@ -92,10 +91,10 @@ def objective(trial, cmd_args):
     )
 
     end_time = time.time()
-    print(f"Trial took: {(end_time - start_time) / 60:.2f} s")
-    
+    print(f"Trial took: {(end_time - start_time) / 60:.2f} min")
+
     trial.set_user_attr("architecture_params", params)
-     
+
     return best_acc
 
 

--- a/clf_optuna.py
+++ b/clf_optuna.py
@@ -1,7 +1,9 @@
 import optuna
-from torch import conv1d
+import time
+
 
 import clf_utils
+
 
 
 def suggest_architecture(trial):
@@ -51,6 +53,7 @@ def suggest_architecture(trial):
 
 
 def objective(trial, cmd_args):
+    start_time = time.time() 
     params = suggest_architecture(trial)
 
     rot = trial.suggest_int("augm_rotation", 5, 20, step=5)
@@ -88,8 +91,11 @@ def objective(trial, cmd_args):
         optuna_trial=trial,
     )
 
+    end_time = time.time()
+    print(f"Trial took: {(end_time - start_time):.2f} s")
+    
     trial.set_user_attr("architecture_params", params)
-
+     
     return best_acc
 
 

--- a/clf_optuna.py
+++ b/clf_optuna.py
@@ -92,7 +92,7 @@ def objective(trial, cmd_args):
     )
 
     end_time = time.time()
-    print(f"Trial took: {(end_time - start_time):.2f} s")
+    print(f"Trial took: {(end_time - start_time) / 60:.2f} s")
     
     trial.set_user_attr("architecture_params", params)
      

--- a/clf_optuna.py
+++ b/clf_optuna.py
@@ -85,7 +85,7 @@ def objective(trial, cmd_args):
         lr=lr,
         betas=(beta1, beta2),
         weight_decay=wd,
-        run_optuna=True,
+        optuna_trial=trial,
     )
 
     trial.set_user_attr("architecture_params", params)

--- a/clf_utils.py
+++ b/clf_utils.py
@@ -34,7 +34,6 @@ def prepare_clf_data(
         manual_seed=manual_seed,
         augment_ops=aug_ops,
     )
-    print("Dataset Loaded.")
 
     train_loader = DataLoader(
         train_data,
@@ -54,7 +53,6 @@ def prepare_clf_data(
             True if utils.DEVICE is not None and utils.DEVICE.type == "cuda" else False
         ),
     )
-    print("DataLoaders Created.")
 
     return train_loader, val_loader
 
@@ -76,7 +74,6 @@ def get_clf(
             params = json.load(file)
 
     clf = select_classifier(domain_name.upper(), params=params)
-    print("Classifier Selected.")
 
     return clf
 
@@ -106,7 +103,6 @@ def train_clf(
     )
 
     clf = trainer.train(train_loader, val_loader, trial=optuna_trial)
-    
     print(f"Best validation accuracy: {trainer.best_acc}")
     
     return (

--- a/clf_utils.py
+++ b/clf_utils.py
@@ -1,6 +1,8 @@
 from typing import Any, Tuple, List, Optional
 import json
 from torch.utils.data import DataLoader
+import optuna
+import time
 
 from eval_models.clf_models import select_classifier, ClfTrainer, BaseClf
 import utils
@@ -91,7 +93,7 @@ def train_clf(
     lr: float,
     betas: Tuple[float, float],
     weight_decay: float,
-    run_optuna: bool = False,
+    optuna_trial: Optional[optuna.Trial] = None
 ):
     trainer = ClfTrainer(
         clf,
@@ -101,15 +103,15 @@ def train_clf(
         lr=lr,
         betas=betas,
         weight_decay=weight_decay,
-        run_optuna=run_optuna,
+        run_optuna=optuna_trial is not None,
     )
-    print("Trainer Created. Starting Training...")
 
-    clf = trainer.train(train_loader, val_loader)
-
-    print("Training Finished.")
+    start_time = time.time() 
+    clf = trainer.train(train_loader, val_loader, trial=optuna_trial)
+    end_time = time.time() 
+    
     print(f"Best validation accuracy: {trainer.best_acc}")
-
+    print(f"Trial took: {(end_time - start_time):.2f} s")
     return (
         clf,
         trainer.best_acc,

--- a/clf_utils.py
+++ b/clf_utils.py
@@ -2,7 +2,6 @@ from typing import Any, Tuple, List, Optional
 import json
 from torch.utils.data import DataLoader
 import optuna
-import time
 
 from eval_models.clf_models import select_classifier, ClfTrainer, BaseClf
 import utils
@@ -106,12 +105,10 @@ def train_clf(
         run_optuna=optuna_trial is not None,
     )
 
-    start_time = time.time() 
     clf = trainer.train(train_loader, val_loader, trial=optuna_trial)
-    end_time = time.time() 
     
     print(f"Best validation accuracy: {trainer.best_acc}")
-    print(f"Trial took: {(end_time - start_time):.2f} s")
+    
     return (
         clf,
         trainer.best_acc,

--- a/eval_models/clf_models.py
+++ b/eval_models/clf_models.py
@@ -118,6 +118,7 @@ class ClfTrainer:
         lr: float = 1e-3,
         betas: Tuple[float, float] = (0.9, 0.999),
         weight_decay: float = 0.0,
+        run_optuna: bool = False
     ):
         self.clf: BaseClf = clf
         self.lr: float = lr
@@ -141,7 +142,8 @@ class ClfTrainer:
         self.val_acc: List[float] = []
 
         self.best_acc: float = 0.0
-
+        
+        self.run_optuna = run_optuna
     def run_loop(self, loader: DataLoader[Any], train: bool = True):
         loss_total = 0
         acc_total = 0
@@ -176,10 +178,9 @@ class ClfTrainer:
         train_loader: DataLoader[Any],
         val_loader: DataLoader[Any],
         *,
-        run_optuna: bool = False,
         trial: Optional[optuna.Trial] = None,
     ):
-        if run_optuna and trial is None:
+        if self.run_optuna and trial is None:
             raise ValueError("If run_optuna is True, trial must be provided.")
 
         best_clf_state_dict: Optional[dict] = None
@@ -217,7 +218,7 @@ class ClfTrainer:
                     print(f"Patience {patience_cnt} reached its limit {self.patience}.")
                     break
 
-            if run_optuna:
+            if self.run_optuna:
                 trial.report(val_acc, epoch)  # type: ignore
                 if trial.should_prune():  # type: ignore
                     raise optuna.exceptions.TrialPruned()

--- a/eval_models/clf_models.py
+++ b/eval_models/clf_models.py
@@ -118,7 +118,7 @@ class ClfTrainer:
         lr: float = 1e-3,
         betas: Tuple[float, float] = (0.9, 0.999),
         weight_decay: float = 0.0,
-        run_optuna: bool = False
+        run_optuna: bool = False,
     ):
         self.clf: BaseClf = clf
         self.lr: float = lr
@@ -142,11 +142,13 @@ class ClfTrainer:
         self.val_acc: List[float] = []
 
         self.best_acc: float = 0.0
-        
+
         self.run_optuna = run_optuna
+
     def run_loop(self, loader: DataLoader[Any], train: bool = True):
         loss_total = 0
         acc_total = 0
+        num_samples = 0
         for x, y in loader:
             # Move batch to the same device as the model
             x = x.to(utils.DEVICE, non_blocking=True)
@@ -167,9 +169,10 @@ class ClfTrainer:
             preds = outputs.argmax(dim=1)
             acc = (preds == y).sum()
             acc_total += acc.item()
+            num_samples += y.size(0)
 
         loss_total /= len(loader)
-        acc_total /= len(loader)
+        acc_total /= num_samples
 
         return loss_total, acc_total
 

--- a/train_eval_clf.py
+++ b/train_eval_clf.py
@@ -13,7 +13,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
 
     _ = parser.add_argument("domain_name", type=str.upper)
-    _ = parser.add_argument("params_file", type=str)
+    _ = parser.add_argument("--params_file", type=str)  # make the changes, so it is only optional -> not needed for optuna
     _ = parser.add_argument("--output_folder", type=str, default="eval_models/")
     # _ = parser.add_argument("--custom_clf", action="store_true")
 


### PR DESCRIPTION
This pull request refactors the classifier training pipeline to improve integration with Optuna for hyperparameter optimization and to clean up logging and argument handling. The main changes include replacing the `run_optuna` flag with direct Optuna trial passing, improving accuracy calculation, and removing unnecessary print statements.