### PR TITLE
Add logic for compilation of forward functions

### DIFF
--- a/LstnetTrainer.py
+++ b/LstnetTrainer.py
@@ -76,6 +76,9 @@ class LstnetTrainer:
             ValueError: If the weight decay is negative.
         """
 
+        if torch.cuda.is_available():
+            torch.set_float32_matmul_precision("high")
+
         self.model = lstnet_model
         self.optim_name = train_params.optim_name
         self.lr = train_params.lr

--- a/LstnetTrainer.py
+++ b/LstnetTrainer.py
@@ -52,6 +52,7 @@ class LstnetTrainer:
         train_params: TrainParams = TrainParams(),
         run_optuna: bool = False,
         optuna_trial: Optional[optuna.Trial] = None,
+        compile_model: bool = False,
     ) -> None:
         """Initialize the LSTNET trainer.
 
@@ -148,6 +149,17 @@ class LstnetTrainer:
         self.run_optuna = run_optuna
         self.optuna_trial = optuna_trial
         self.fin_loss = np.inf
+
+        if compile_model:
+            self.disc_forward = torch.compile(
+                self.disc_forward, mode="default", dynamic=False
+            )
+            self.enc_gen_forward = torch.compile(
+                self.enc_gen_forward, mode="default", dynamic=False
+            )
+            self.eval_forward = torch.compile(
+                self.eval_forward, mode="default", dynamic=False
+            )
 
     def get_trainer_info(self) -> Dict[str, Any]:
         """

--- a/data_preparation.py
+++ b/data_preparation.py
@@ -89,6 +89,7 @@ def get_data_loader(
     persistent_workers: bool = False,
     pin_memory: bool = False,
     collate_fn: Optional[Callable] = None,
+    drop_last: bool = False,
 ) -> DataLoader[Any]:
     """Creates a DataLoader for the given dataset.
 
@@ -117,6 +118,7 @@ def get_data_loader(
         persistent_workers=persistent_workers,
         pin_memory=pin_memory,
         collate_fn=collate_fn,
+        drop_last=drop_last,
     )
 
 
@@ -437,6 +439,7 @@ def get_train_val_loaders(
         shuffle=True,
         pin_memory=pin_memory,
         collate_fn=custom_collate_fn,
+        drop_last=True,  # To ensure consistent batch sizes during training
     )
     val_loader = get_data_loader(
         val_data,
@@ -445,6 +448,7 @@ def get_train_val_loaders(
         shuffle=False,
         pin_memory=pin_memory,
         collate_fn=custom_collate_fn,
+        drop_last=False,  # Getting all data in validation
     )
 
     print("Obtained Data Loader for both training and validation")
@@ -562,6 +566,7 @@ def get_training_loader(
         pin_memory=pin_memory,
         shuffle=True,
         collate_fn=custom_collate_fn,
+        drop_last=True,  # To ensure consistent batch sizes during training
     )
     print("Obtained Data Loader for training")
 

--- a/domain_adaptation.py
+++ b/domain_adaptation.py
@@ -34,7 +34,7 @@ def translate_to_diff_domain(
             all_labels.append(labels)
 
             imgs = imgs.to(utils.DEVICE)
-            trans_imgs = map_fn(imgs)
+            trans_imgs, _ = map_fn(imgs)
             all_trans_imgs.append(trans_imgs.cpu())
 
     trans_igms_tensor = torch.cat(all_trans_imgs)

--- a/loss_functions.py
+++ b/loss_functions.py
@@ -10,7 +10,13 @@ import torch
 from torch import Tensor
 
 from models.lstnet import LSTNET
-from utils import TensorTriplet, TensorQuad, FloatTriplet, FloatQuad
+from utils import (
+    TensorTriplet,
+    TensorQuad,
+    FloatTriplet,
+    FloatQuad,
+    convert_tensor_tuple_to_floats,
+)
 
 
 class WeightIndex(IntEnum):
@@ -186,7 +192,7 @@ def compute_discriminator_loss(
     if return_grad:
         return res_with_grad
 
-    return (res_with_grad[0].item(), res_with_grad[1].item(), res_with_grad[2].item())
+    return convert_tensor_tuple_to_floats(res_with_grad)
 
 
 # Overloads for type checking
@@ -274,12 +280,7 @@ def compute_cc_loss(
     if return_grad:
         return res_with_grad
 
-    return (
-        res_with_grad[0].item(),
-        res_with_grad[1].item(),
-        res_with_grad[2].item(),
-        res_with_grad[3].item(),
-    )
+    return convert_tensor_tuple_to_floats(res_with_grad)
 
 
 # Overloads for type checking
@@ -370,4 +371,4 @@ def compute_enc_gen_loss(
     if return_grad:
         return res_with_grad
 
-    return (res_with_grad[0].item(), res_with_grad[1].item(), res_with_grad[2].item())
+    return convert_tensor_tuple_to_floats(res_with_grad)

--- a/run.py
+++ b/run.py
@@ -100,6 +100,12 @@ def add_train_args(parser: argparse.ArgumentParser):
         help="List of 7 float weights",
     )
 
+    = parser.add_argument(
+        "--compile",
+        action="store_true",
+        help="If set, the model will be compiled before training (pytorch compile).",
+    )
+
     _ = parser.add_argument("--optuna", action="store_true")
     _ = parser.add_argument("--optuna_study_name", type=str, default="lstnet_study")
     _ = parser.add_argument(

--- a/run.py
+++ b/run.py
@@ -100,7 +100,7 @@ def add_train_args(parser: argparse.ArgumentParser):
         help="List of 7 float weights",
     )
 
-    = parser.add_argument(
+    _ = parser.add_argument(
         "--compile",
         action="store_true",
         help="If set, the model will be compiled before training (pytorch compile).",
@@ -306,6 +306,7 @@ def run_training(
         manual_seed=cmd_args.manual_seed,
         augm_ops=augm_ops,
         train_params=train_params,
+        compile_model=cmd_args.compile,
     )
 
     if return_model:

--- a/train.py
+++ b/train.py
@@ -39,6 +39,7 @@ def run(
     train_params: TrainParams = TrainParams(),
     optuna: Literal[False] = False,
     optuna_trial: Optional[optuna.Trial] = None,
+    compile_model: bool = False,
 ) -> LSTNET: ...
 @overload
 def run(
@@ -60,6 +61,7 @@ def run(
     train_params: TrainParams = TrainParams(),
     optuna: Literal[True],
     optuna_trial: Optional[optuna.Trial] = None,
+    compile_model: bool = False,
 ) -> Tuple[LSTNET, Dict[str, Any]]: ...
 def run(
     first_domain_name: str,
@@ -80,6 +82,7 @@ def run(
     train_params: TrainParams = TrainParams(),
     optuna: bool = False,
     optuna_trial: Optional[optuna.Trial] = None,
+    compile_model: bool = False,
 ) -> Union[LSTNET, Tuple[LSTNET, Dict[str, Any]]]:
     """Train the LSTNET model.
 
@@ -163,6 +166,7 @@ def run(
         train_params=train_params,
         run_optuna=optuna,
         optuna_trial=optuna_trial,
+        compile_model=compile_model,
     )
     print("Starting train and validate")
     trained_model = trainer.fit()

--- a/utils.py
+++ b/utils.py
@@ -282,3 +282,11 @@ def init_device():
         DEVICE = get_device()
 
     print(f"Using device: {DEVICE}")
+
+
+def convert_tensor_tuple_to_floats(
+    tuple_tensor: Tuple[Tensor, ...],
+) -> Tuple[float, ...]:
+    """Convert a tuple of tensors to a tuple of floats."""
+
+    return tuple(t.item() for t in tuple_tensor)


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the LSTNET training pipeline, with a focus on simplifying the domain mapping API, improving loss computation consistency, and adding support for PyTorch model compilation. The most significant changes include standardizing the mapping methods to always return both the generated image and its latent representation, refactoring the trainer's forward and update loops for clarity and modularity, and adding an option to compile the model for potential performance gains.
